### PR TITLE
fix Arxiv link

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Large reasoning models (LRMs), such as OpnAI-o1 and Deepseek-R1, have demonstrat
 
 We propose **R1-searcher**, utilizing a *two-stage outcome-supervision reinforcement learning* approach to enable the model to learn to invoke web search during the reasoning process: first allowing the model to learn how to invoke web search, and then teaching it how to effectively use that search engine. This method does not require any instruction fine-tuning for cold start, and at the same time, it is compatible with existing Base LLMs or Chat LLMs. We will open-source the training code, inference code, model checkpoints, and the detailed technical report.
 
-- Arxiv: https://arxiv.org/pdf/2503.05592 
+- Arxiv: https://arxiv.org/pdf/2503.05592
 - Model:
     - Qwen-2.5-7B-Base-RAG-RL: https://huggingface.co/XXsongLALA/Qwen-2.5-7B-base-RAG-RL
     - Llama-3.1-8B-Instruct-RAG-RL: https://huggingface.co/XXsongLALA/Llama-3.1-8B-instruct-RAG-RL


### PR DESCRIPTION
currently if we click on the link it shows
<img width="614" alt="image" src="https://github.com/user-attachments/assets/b621cd33-cbc6-4184-ab95-91a198fd4d38" />
due to extra trailing space.